### PR TITLE
Arguments builder/1.0.1

### DIFF
--- a/packages/arguments-builder/src/bin/config.ts
+++ b/packages/arguments-builder/src/bin/config.ts
@@ -14,7 +14,7 @@ const outputSchema = z.object({
     .optional(),
   loon: z
     .object({
-      template: z.string(),
+      template: z.string().optional(),
       path: z.string().optional(),
     })
     .optional(),

--- a/packages/arguments-builder/src/bin/index.ts
+++ b/packages/arguments-builder/src/bin/index.ts
@@ -1,3 +1,5 @@
+#!/usr/bin/env node
+
 import { program } from 'commander';
 import { buildBoxJsSettings } from './boxjs';
 import { getBuilder } from './builder';

--- a/packages/arguments-builder/src/core/index.ts
+++ b/packages/arguments-builder/src/core/index.ts
@@ -93,16 +93,22 @@ export class ArgumentsBuilder {
           type = 'select';
         }
         result += ` = ${type}`;
-        if (typeof arg.defaultValue === 'string') {
-          result += `,"${arg.defaultValue}"`;
-        } else if (['number', 'boolean'].includes(typeof arg.defaultValue)) {
-          result += `,${arg.defaultValue}`;
-        } else {
-          result += `,""`;
+        function getValue(val: any) {
+          if (typeof val === 'string') {
+            return `"${val}"`;
+          }
+          if (['number', 'boolean'].includes(typeof val)) {
+            return val;
+          }
+          return '';
         }
+        result += `,${getValue(arg.defaultValue)}`;
         if (arg.options) {
           result += ',';
-          result += arg.options.map((option) => `"${option.key}"`).join(',');
+          result += arg.options
+            .filter((item) => item !== arg.defaultValue)
+            .map((option) => `${getValue(option.key)}`)
+            .join(',');
         }
         if (arg.name) {
           result += `,tag=${arg.name}`;


### PR DESCRIPTION
This pull request includes a refactoring of the `ArgumentsBuilder` class to improve code readability and maintainability by introducing a helper function for value formatting.

Code readability and maintainability improvements:

* [`packages/arguments-builder/src/core/index.ts`](diffhunk://#diff-342ad6bab1c90e6c5626685f3745a1d36d94a663870ec7d16537581a0e68531fL96-R111): Refactored the value formatting logic into a helper function `getValue` to handle different types of default values (`string`, `number`, `boolean`) and used this helper function for both `arg.defaultValue` and `arg.options` processing.