### PR TITLE
feat: 新增模版变量 now 用于输出当前时间

### DIFF
--- a/.changeset/five-hornets-live.md
+++ b/.changeset/five-hornets-live.md
@@ -1,0 +1,5 @@
+---
+"@iringo/arguments-builder": minor
+---
+
+新增模版变量 now 用于输出当前时间

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @e2e/* --parallel=10"
+    "build": "cross-env NX_DAEMON=false nx run-many -t build --exclude @examples/* @e2e/* --parallel=10",
+    "change": "changeset"
   },
   "author": "",
   "description": "",

--- a/packages/arguments-builder/README.md
+++ b/packages/arguments-builder/README.md
@@ -1,0 +1,130 @@
+# @iringo/arguments-builder
+
+用于统一维护项目参数配置的构建
+
+## 安装
+
+```bash
+pnpm add -D @iringo/arguments-builder
+# or
+npm add -D @iringo/arguments-builder
+```
+
+## 配置文件
+
+默认读取 `arguments-builder.config.(ts|js|mjs)` 文件，支持 `-c` 或 `--config` 指定配置文件
+
+```ts
+import { defineConfig } from "@iringo/arguments-builder";
+
+export default defineConfig({
+  // ...
+});
+```
+
+```js
+/**
+ * @type {import('@iringo/arguments-builder').ArgumentsBuilderConfig}
+ */
+module.exports = {
+  // ...
+};
+```
+
+## 配置
+
+### ArgumentsBuilderConfig
+
+| 参数        | 类型                            | 描述           |
+| ----------- | ------------------------------- | -------------- |
+| output      | [Output](#Output)               | 输出文件配置   |
+| args        | [ArgumentItem](#ArgumentItem)[] | 参数配置       |
+| boxJsConfig | BoxJsConfig                     | boxjs 特殊配置 |
+
+### Output
+
+| 参数          | 类型                                    | 描述                                                                                                                                        |
+| ------------- | --------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| surge         | { path?: string; template?: string; }   | surge 输出内容配置。`path` 为输出路径，`template` 为模版路径                                                                                |
+| loon          | { path?: string; template?: string; }   | loon 输出内容配置。`path` 为输出路径，`template` 为模版路径                                                                                 |
+| boxjsSettings | { path?: string; }                      | boxjs 的 settings 部分内容的输出路径                                                                                                        |
+| dts           | { path?: string; isExported?: boolean } | 输出 dts 文件的配置。`isExported` 默认根据输出文件后缀自动判断，及 `.d.ts` 文件认为是全局类型，则 `isExported` 为 `false`；`.ts` 文件则反之 |
+
+### ArgumentItem
+
+| 参数         | 类型                                                                                                                                  | 描述                                                  |
+| ------------ | ------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------- |
+| key          | string **（必填）**                                                                                                                   | 参数 key                                              |
+| type         | 'string' \| 'number' \| 'boolean' \| 'array' **（必填）**                                                                             | 参数类型                                              |
+| boxJsType    | 'text' \| 'slider' \| 'boolean' \| 'textarea' \| 'radios' \| 'checkboxes' \| 'colorpicker' \| 'number' \| 'selects' \| 'modalSelects' | 自动的映射关系无法满足时，可以使用 boxJsType 来自定义 |
+| name         | string                                                                                                                                | 参数描述                                              |
+| description  | string                                                                                                                                | 参数简介                                              |
+| defaultValue | any                                                                                                                                   | 默认值                                                |
+| options      | array                                                                                                                                 | 选项                                                  |
+| placeholder  | string                                                                                                                                | 输入框占位符                                          |
+| exclude      | Array<'surge'\| 'loon' \| 'boxjs' \| 'dts'>                                                                                           | 当前参数在哪些平台上不生效                            |
+
+## CLI
+
+### 输出 dts 文件
+
+用于开发阶段输出根据当前参数配置输出类型文件，方便类型推导
+
+```bash
+npx arguments-builder dts
+```
+
+### 生成 module 文件
+
+#### 一键生成
+
+根据模版自动生成 `surge`、`loon` 的 module 文件，以及 `boxjs` 的 settings 部分的 JSON 文件
+
+```bash
+npx arguments-builder build
+```
+
+#### 单独生成
+
+命令行工具保留了分别生成单独平台文件的能力
+
+```bash
+npx arguments-builder (surge|loon|boxjs)
+```
+
+### 通用参数
+
+所有命令均支持 `-c` 或 `--config` 指定配置文件。
+
+例如以下场景
+
+```ts
+// arguments-builder.config.ts
+import { defineConfig } from "@iringo/arguments-builder";
+
+export default defineConfig({
+  // ...
+});
+
+// arguments-builder.beta.config.ts
+import defaultConfig from "./arguments-builder.config.ts";
+import { defineConfig } from "@iringo/arguments-builder";
+
+export default defineConfig({
+  ...defaultConfig,
+  args: [
+    ...defaultConfig.args,
+    {
+      // ...
+    },
+  ],
+});
+```
+
+## Node API
+
+```ts
+import { ArgumentsBuilder } from "@iringo/arguments-builder";
+
+const argumentsBuilder = new ArgumentsBuilder();
+```

--- a/packages/arguments-builder/package.json
+++ b/packages/arguments-builder/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "commander": "^12.1.0",
+    "date-fns": "^4.1.0",
     "handlebars": "^4.7.8",
     "jiti": "^2.1.0",
     "rslog": "^1.2.3",
@@ -32,5 +33,8 @@
     "access": "public",
     "registry": "https://registry.npmjs.org/"
   },
-  "files": ["dist", "CHANGELOG.md"]
+  "files": [
+    "dist",
+    "CHANGELOG.md"
+  ]
 }

--- a/packages/arguments-builder/src/bin/handlebars.ts
+++ b/packages/arguments-builder/src/bin/handlebars.ts
@@ -1,3 +1,12 @@
+import { format } from 'date-fns';
 import handlebars from 'handlebars';
+
+handlebars.registerHelper('now', (formatStr: string) => {
+  const now = new Date();
+  if (formatStr) {
+    return format(now, formatStr);
+  }
+  return now.toISOString();
+});
 
 export { handlebars };

--- a/packages/arguments-builder/src/index.ts
+++ b/packages/arguments-builder/src/index.ts
@@ -3,6 +3,8 @@ import type { ArgumentsBuilderConfig } from './bin';
 export * from './core';
 export * from './core/types';
 
+export type { ArgumentsBuilderConfig };
+
 export function defineConfig(config: ArgumentsBuilderConfig) {
   return config;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       commander:
         specifier: ^12.1.0
         version: 12.1.0
+      date-fns:
+        specifier: ^4.1.0
+        version: 4.1.0
       handlebars:
         specifier: ^4.7.8
         version: 4.7.8
@@ -1273,6 +1276,9 @@ packages:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
     engines: {node: '>=4'}
     hasBin: true
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
 
   debug@4.3.7:
     resolution: {integrity: sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==}
@@ -3867,6 +3873,8 @@ snapshots:
       which: 2.0.2
 
   cssesc@3.0.0: {}
+
+  date-fns@4.1.0: {}
 
   debug@4.3.7:
     dependencies:


### PR DESCRIPTION
模版格式 `{{now "YYYY-MM-DD HH:mm:ss"}}`，格式化参考 date-fns 的 [format](https://date-fns.org/v4.1.0/docs/format) 方法