### PR TITLE
fix: 修复 surge 模板默认值生成错误的问题

### DIFF
--- a/.changeset/few-eyes-count.md
+++ b/.changeset/few-eyes-count.md
@@ -1,0 +1,5 @@
+---
+"@iringo/arguments-builder": patch
+---
+
+修复 surge 模板默认值生成错误的问题

--- a/packages/arguments-builder/src/core/index.ts
+++ b/packages/arguments-builder/src/core/index.ts
@@ -37,15 +37,18 @@ export class ArgumentsBuilder {
 
   public buildSurgeArguments() {
     const args = this.getArgumentByScope('surge');
-    const argumentsText = args
-      .map((arg) => {
-        let result = arg.key;
-        if (arg.defaultValue) {
-          result += `:${['string', 'number', 'boolean'].includes(typeof arg.defaultValue) ? arg.defaultValue : `""`}`;
-        }
-        return result;
-      })
-      .join(',');
+    const getValue = (defaultValue: any) => {
+      switch (typeof defaultValue) {
+        case 'string':
+          return `"${defaultValue}"`;
+        case 'number':
+        case 'boolean':
+          return defaultValue;
+        default:
+          return '""';
+      }
+    };
+    const argumentsText = args.map((arg) => `${arg.key}:${getValue(arg.defaultValue)}`).join(',');
 
     const argumentsDescription = args
       .map((arg) => {

--- a/packages/arguments-builder/tests/core.test.ts
+++ b/packages/arguments-builder/tests/core.test.ts
@@ -172,14 +172,16 @@ describe('ArgumentsBuilder', () => {
     const result = builder.buildSurgeArguments();
     it('should generate correct Surge arguments', () => {
       expect(result.argumentsText).not.toContain('Switch');
-      expect(result.argumentsText).toContain('NextHour.Provider:ColorfulClouds');
+      expect(result.argumentsText).toContain('NextHour.Provider:"ColorfulClouds"');
     });
     it('should generate correct Surge arguments description', () => {
       expect(result.argumentsDescription).toContain('[未来一小时降水强度]数据源\n    ├ WeatherKit');
     });
     it('should generate correct Surge script params', () => {
-      expect(result.scriptParams).toContain('NextHour.Provider={{{NextHour.Provider}}}&AQI.Provider={{{AQI.Provider}}}&')
-    })
+      expect(result.scriptParams).toContain(
+        'NextHour.Provider={{{NextHour.Provider}}}&AQI.Provider={{{AQI.Provider}}}&',
+      );
+    });
   });
 
   describe('buildLoonArguments', () => {


### PR DESCRIPTION
This pull request includes changes to fix a bug in the `ArgumentsBuilder` class, specifically related to the generation of default values for the Surge template. The most important changes include updates to the `ArgumentsBuilder` class to handle default values correctly and adjustments to the corresponding tests to ensure the fix works as intended.

### Bug Fixes:

* [`packages/arguments-builder/src/core/index.ts`](diffhunk://#diff-342ad6bab1c90e6c5626685f3745a1d36d94a663870ec7d16537581a0e68531fL40-R51): Modified the `buildSurgeArguments` method to correctly handle different types of default values (string, number, boolean) using a new `getValue` function.

### Tests:

* [`packages/arguments-builder/tests/core.test.ts`](diffhunk://#diff-79868fc3669abce430496fa65024c22f332ae6cdad1aa8afa014519b3b4bda05L175-R184): Updated the test cases to reflect the corrected handling of string default values by enclosing them in double quotes.